### PR TITLE
An empty target must be dealt with

### DIFF
--- a/Classes/Utility/Convert.php
+++ b/Classes/Utility/Convert.php
@@ -203,9 +203,13 @@ class Convert
         $xml[] = '		<body>';
 
         foreach ($LOCAL_LANG[$langKey] as $key => $data) {
-            if (is_array($data) && isset($data[0]['target'])) {
+            if (is_array($data)) {
                 $source = $data[0]['source'];
-                $target = $data[0]['target'];
+                if (isset($data[0]['target'])) {
+                    $target = $data[0]['target'];
+                } else {
+                    $target = '';
+                }
             } else {
                 $source = $LOCAL_LANG['default'][$key];
                 $target = $data;

--- a/Classes/Utility/Convert.php
+++ b/Classes/Utility/Convert.php
@@ -203,7 +203,7 @@ class Convert
         $xml[] = '		<body>';
 
         foreach ($LOCAL_LANG[$langKey] as $key => $data) {
-            if (is_array($data)) {
+            if (is_array($data) && isset($data[0]['target'])) {
                 $source = $data[0]['source'];
                 $target = $data[0]['target'];
             } else {


### PR DESCRIPTION
If I convert the locallang_db.xml from the extension mbi_products_categories, then it ends up in an exception.


(1/1) #1476107295 TYPO3\CMS\Core\Error\Exception
PHP Warning: Undefined array key "target" in /var/www/html/develop/typo3conf/ext/ew_llxml2xliff/Classes/Utility/Convert.php line 207
