### PR TITLE
Performance improvement if project have a lot of extensions

### DIFF
--- a/Classes/Controller/FileController.php
+++ b/Classes/Controller/FileController.php
@@ -41,7 +41,7 @@ class FileController extends ActionController
         $extensions = $this->getLocalExtensions();
         $extensionsWithFileToConvert = [];
         foreach ($extensions as $extension) {
-            if (isset($extension['type']) && $this->getFilesOfExtension($extension['key'])) {
+            if (isset($extension['type'])) {
                 $extensionsWithFileToConvert[] = $extension;
             }
         }


### PR DESCRIPTION
if Project have a lot of extensions, do not scan all extension on module load to avoid long time for backend module to load.